### PR TITLE
feat(eslint-plugin): Add testing-library and jsx-a11y rules.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,14 +15,6 @@ module.exports = {
         ],
       },
     ],
-    'no-restricted-syntax': [
-      'error',
-      {
-        selector: 'Literal[value=warn]',
-        message:
-          "We shouldn't use warnings in the base config, we should override errors to warnings in app configs. It's better to use INCONSISTENCY.",
-      },
-    ],
   },
   overrides: [
     { files: '*.js', extends: 'plugin:@superdispatch/node' },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,29 @@
 'use strict';
 
 module.exports = {
+  rules: {
+    'no-restricted-imports': [
+      'error',
+      {
+        paths: [
+          {
+            name: 'no-import-warning',
+            importNames: ['WARNING'],
+            message:
+              "We shouldn't use warnings in the base config, we should override errors to warnings in app configs. It's better to use INCONSISTENCY.",
+          },
+        ],
+      },
+    ],
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: 'Literal[value=warn]',
+        message:
+          "We shouldn't use warnings in the base config, we should override errors to warnings in app configs. It's better to use INCONSISTENCY.",
+      },
+    ],
+  },
   overrides: [
     { files: '*.js', extends: 'plugin:@superdispatch/node' },
     { files: '*.ts', extends: 'plugin:@superdispatch/typescript' },

--- a/packages/eslint-plugin/configs/__tests__/jest.spec.js
+++ b/packages/eslint-plugin/configs/__tests__/jest.spec.js
@@ -106,6 +106,19 @@ it('extends dependencies', async () => {
         "error",
       ],
       "testing-library/no-debug": Array [
+        "warn",
+      ],
+      "testing-library/no-dom-import": Array [
+        "error",
+        "react",
+      ],
+      "testing-library/no-wait-for-empty-callback": Array [
+        "error",
+      ],
+      "testing-library/prefer-presence-queries": Array [
+        "error",
+      ],
+      "testing-library/prefer-screen-queries": Array [
         "error",
       ],
     }
@@ -117,13 +130,6 @@ it('not changes in dev mode', async () => {
 
   expect(rules).toMatchInlineSnapshot(`
 Snapshot Diff:
-- First value
-+ Second value
-
-@@ --- --- @@
-    "testing-library/no-debug": Array [
--     "error",
-+     "warn",
-    ],
+Compared values have no visual difference.
 `);
 });

--- a/packages/eslint-plugin/configs/__tests__/jest.spec.js
+++ b/packages/eslint-plugin/configs/__tests__/jest.spec.js
@@ -19,6 +19,7 @@ it('extends dependencies', async () => {
       "parserOptions": Object {},
       "plugins": Array [
         "jest",
+        "testing-library",
       ],
       "settings": Object {},
     }
@@ -95,6 +96,18 @@ it('extends dependencies', async () => {
       "jest/valid-expect-in-promise": Array [
         "error",
       ],
+      "testing-library/await-async-query": Array [
+        "error",
+      ],
+      "testing-library/await-async-utils": Array [
+        "error",
+      ],
+      "testing-library/no-await-sync-query": Array [
+        "error",
+      ],
+      "testing-library/no-debug": Array [
+        "error",
+      ],
     }
   `);
 });
@@ -103,7 +116,14 @@ it('not changes in dev mode', async () => {
   const rules = await getDevConfigDiff('jest');
 
   expect(rules).toMatchInlineSnapshot(`
-    Snapshot Diff:
-    Compared values have no visual difference.
-  `);
+Snapshot Diff:
+- First value
++ Second value
+
+@@ --- --- @@
+    "testing-library/no-debug": Array [
+-     "error",
++     "warn",
+    ],
+`);
 });

--- a/packages/eslint-plugin/configs/__tests__/react.spec.js
+++ b/packages/eslint-plugin/configs/__tests__/react.spec.js
@@ -34,55 +34,43 @@ it('extends dependencies', async () => {
         "error",
       ],
       "jsx-a11y/accessible-emoji": Array [
-        "warn",
+        "error",
       ],
-      "jsx-a11y/alt-text": Array [
-        "warn",
-      ],
-      "jsx-a11y/anchor-has-content": Array [
-        "warn",
-      ],
-      "jsx-a11y/anchor-is-valid": Array [
-        "warn",
-        Object {
-          "aspects": Array [
-            "noHref",
-            "invalidHref",
-          ],
-        },
+      "jsx-a11y/aria-activedescendant-has-tabindex": Array [
+        "error",
       ],
       "jsx-a11y/aria-props": Array [
-        "warn",
+        "error",
       ],
       "jsx-a11y/aria-proptypes": Array [
-        "warn",
+        "error",
       ],
       "jsx-a11y/aria-role": Array [
-        "warn",
+        "error",
         Object {
           "ignoreNonDOM": true,
         },
       ],
-      "jsx-a11y/aria-unsupported-elements": Array [
-        "warn",
-      ],
-      "jsx-a11y/heading-has-content": Array [
-        "warn",
-      ],
-      "jsx-a11y/img-redundant-alt": Array [
-        "warn",
-      ],
       "jsx-a11y/no-access-key": Array [
-        "warn",
+        "error",
       ],
-      "jsx-a11y/no-distracting-elements": Array [
-        "warn",
+      "jsx-a11y/no-autofocus": Array [
+        "error",
       ],
       "jsx-a11y/no-redundant-roles": Array [
-        "warn",
+        "error",
+      ],
+      "jsx-a11y/role-has-required-aria-props": Array [
+        "error",
       ],
       "jsx-a11y/role-supports-aria-props": Array [
-        "warn",
+        "error",
+      ],
+      "jsx-a11y/scope": Array [
+        "error",
+      ],
+      "jsx-a11y/tabindex-no-positive": Array [
+        "error",
       ],
       "react-hooks/exhaustive-deps": Array [
         "error",
@@ -236,6 +224,55 @@ Snapshot Diff:
 
 @@ --- --- @@
     "@superdispatch/jsx-no-spread-object-expression": Array [
+-     "error",
++     "warn",
+    ],
+    "jsx-a11y/accessible-emoji": Array [
+-     "error",
++     "warn",
+    ],
+    "jsx-a11y/aria-activedescendant-has-tabindex": Array [
+-     "error",
++     "warn",
+    ],
+    "jsx-a11y/aria-props": Array [
+-     "error",
++     "warn",
+    ],
+    "jsx-a11y/aria-proptypes": Array [
+-     "error",
++     "warn",
+    ],
+    "jsx-a11y/aria-role": Array [
+-     "error",
++     "warn",
+      Object {
+@@ --- --- @@
+    "jsx-a11y/no-access-key": Array [
+-     "error",
++     "warn",
+    ],
+    "jsx-a11y/no-autofocus": Array [
+-     "error",
++     "warn",
+    ],
+    "jsx-a11y/no-redundant-roles": Array [
+-     "error",
++     "warn",
+    ],
+    "jsx-a11y/role-has-required-aria-props": Array [
+-     "error",
++     "warn",
+    ],
+    "jsx-a11y/role-supports-aria-props": Array [
+-     "error",
++     "warn",
+    ],
+    "jsx-a11y/scope": Array [
+-     "error",
++     "warn",
+    ],
+    "jsx-a11y/tabindex-no-positive": Array [
 -     "error",
 +     "warn",
     ],

--- a/packages/eslint-plugin/configs/__tests__/react.spec.js
+++ b/packages/eslint-plugin/configs/__tests__/react.spec.js
@@ -21,6 +21,7 @@ it('extends dependencies', async () => {
         },
       },
       "plugins": Array [
+        "jsx-a11y",
         "react-hooks",
         "react",
       ],
@@ -31,6 +32,57 @@ it('extends dependencies', async () => {
     Object {
       "@superdispatch/jsx-no-spread-object-expression": Array [
         "error",
+      ],
+      "jsx-a11y/accessible-emoji": Array [
+        "warn",
+      ],
+      "jsx-a11y/alt-text": Array [
+        "warn",
+      ],
+      "jsx-a11y/anchor-has-content": Array [
+        "warn",
+      ],
+      "jsx-a11y/anchor-is-valid": Array [
+        "warn",
+        Object {
+          "aspects": Array [
+            "noHref",
+            "invalidHref",
+          ],
+        },
+      ],
+      "jsx-a11y/aria-props": Array [
+        "warn",
+      ],
+      "jsx-a11y/aria-proptypes": Array [
+        "warn",
+      ],
+      "jsx-a11y/aria-role": Array [
+        "warn",
+        Object {
+          "ignoreNonDOM": true,
+        },
+      ],
+      "jsx-a11y/aria-unsupported-elements": Array [
+        "warn",
+      ],
+      "jsx-a11y/heading-has-content": Array [
+        "warn",
+      ],
+      "jsx-a11y/img-redundant-alt": Array [
+        "warn",
+      ],
+      "jsx-a11y/no-access-key": Array [
+        "warn",
+      ],
+      "jsx-a11y/no-distracting-elements": Array [
+        "warn",
+      ],
+      "jsx-a11y/no-redundant-roles": Array [
+        "warn",
+      ],
+      "jsx-a11y/role-supports-aria-props": Array [
+        "warn",
       ],
       "react-hooks/exhaustive-deps": Array [
         "error",

--- a/packages/eslint-plugin/configs/internal/error-codes.js
+++ b/packages/eslint-plugin/configs/internal/error-codes.js
@@ -5,7 +5,7 @@ const isDevMode =
 
 const OFF = 'off';
 const ERROR = 'error';
-const WARNING = 'warn'; // eslint-disable-line no-restricted-syntax
+const WARNING = 'warn';
 const DEPT = isDevMode ? OFF : WARNING;
 const INCONSISTENCY = isDevMode ? WARNING : ERROR;
 

--- a/packages/eslint-plugin/configs/internal/error-codes.js
+++ b/packages/eslint-plugin/configs/internal/error-codes.js
@@ -5,8 +5,8 @@ const isDevMode =
 
 const OFF = 'off';
 const ERROR = 'error';
-const WARNING = 'warn';
+const WARNING = 'warn'; // eslint-disable-line no-restricted-syntax
 const DEPT = isDevMode ? OFF : WARNING;
 const INCONSISTENCY = isDevMode ? WARNING : ERROR;
 
-module.exports = { OFF, DEPT, ERROR, WARNING, INCONSISTENCY };
+module.exports = { OFF, DEPT, ERROR, INCONSISTENCY };

--- a/packages/eslint-plugin/configs/internal/error-codes.js
+++ b/packages/eslint-plugin/configs/internal/error-codes.js
@@ -9,4 +9,4 @@ const WARNING = 'warn';
 const DEPT = isDevMode ? OFF : WARNING;
 const INCONSISTENCY = isDevMode ? WARNING : ERROR;
 
-module.exports = { OFF, DEPT, ERROR, INCONSISTENCY };
+module.exports = { OFF, DEPT, ERROR, WARNING, INCONSISTENCY };

--- a/packages/eslint-plugin/configs/jest.js
+++ b/packages/eslint-plugin/configs/jest.js
@@ -4,7 +4,7 @@
 
 'use strict';
 
-const { ERROR, INCONSISTENCY } = require('./internal/error-codes');
+const { ERROR } = require('./internal/error-codes');
 
 /**
  * @type {Config}
@@ -15,6 +15,7 @@ module.exports = {
     'plugin:jest/recommended',
     'plugin:jest/style',
     'plugin:testing-library/recommended',
+    'plugin:testing-library/react',
   ],
 
   rules: {
@@ -56,11 +57,26 @@ module.exports = {
     //
     // eslint-plugin-testing-library
     //
+
     /**
-     * Prevents using `debug` function.
+     * Disallow empty callbacks for waitFor and waitForElementToBeRemoved.
      *
-     * @see https://github.com/testing-library/eslint-plugin-testing-library/blob/master/docs/rules/no-debug.md
+     * @see https://github.com/testing-library/eslint-plugin-testing-library/blob/master/docs/rules/no-wait-for-empty-callback.md
      * */
-    'testing-library/no-debug': INCONSISTENCY,
+    'testing-library/no-wait-for-empty-callback': ERROR,
+
+    /**
+     * Enforce specific queries when checking element is present or not.
+     *
+     * @see https://github.com/testing-library/eslint-plugin-testing-library/blob/master/docs/rules/prefer-presence-queries.md
+     * */
+    'testing-library/prefer-presence-queries': ERROR,
+
+    /**
+     * Suggest using screen while using queries.
+     *
+     * @see https://github.com/testing-library/eslint-plugin-testing-library/blob/master/docs/rules/prefer-presence-queries.md
+     * */
+    'testing-library/prefer-screen-queries': ERROR,
   },
 };

--- a/packages/eslint-plugin/configs/jest.js
+++ b/packages/eslint-plugin/configs/jest.js
@@ -4,14 +4,18 @@
 
 'use strict';
 
-const { ERROR } = require('./internal/error-codes');
+const { ERROR, INCONSISTENCY } = require('./internal/error-codes');
 
 /**
  * @type {Config}
  * */
 module.exports = {
   env: { jest: true },
-  extends: ['plugin:jest/recommended', 'plugin:jest/style'],
+  extends: [
+    'plugin:jest/recommended',
+    'plugin:jest/style',
+    'plugin:testing-library/recommended',
+  ],
 
   rules: {
     /**
@@ -48,5 +52,15 @@ module.exports = {
      * @see https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-jasmine-globals.md
      */
     'jest/no-jasmine-globals': ERROR,
+
+    //
+    // eslint-plugin-testing-library
+    //
+    /**
+     * Prevents using `debug` function.
+     *
+     * @see https://github.com/testing-library/eslint-plugin-testing-library/blob/master/docs/rules/no-debug.md
+     * */
+    'testing-library/no-debug': INCONSISTENCY,
   },
 };

--- a/packages/eslint-plugin/configs/react.js
+++ b/packages/eslint-plugin/configs/react.js
@@ -3,14 +3,19 @@
  * */
 'use strict';
 
-const { OFF, ERROR, INCONSISTENCY } = require('./internal/error-codes');
+const {
+  OFF,
+  ERROR,
+  WARNING,
+  INCONSISTENCY,
+} = require('./internal/error-codes');
 
 /**
  * @type {Config}
  * */
 module.exports = {
   env: { browser: true },
-  plugins: ['react', 'react-hooks'],
+  plugins: ['react', 'react-hooks', 'jsx-a11y'],
   extends: ['plugin:react/recommended', 'prettier/react'],
 
   rules: {
@@ -82,5 +87,112 @@ module.exports = {
 
     'react-hooks/rules-of-hooks': ERROR,
     'react-hooks/exhaustive-deps': ERROR,
+
+    //
+    // eslint-plugin-jsx-a11y
+    //
+
+    /**
+     * Enforces to use accessibility attributes with emoji.
+     *
+     * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/accessible-emoji.md
+     * */
+    'jsx-a11y/accessible-emoji': WARNING,
+
+    /**
+     * Enforce that all elements that require alternative text have meaningful information to relay back to the end user.
+     *
+     * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/alt-text.md
+     * */
+    'jsx-a11y/alt-text': WARNING,
+
+    /**
+     * Enforce that anchors have content and that the content is accessible to screen readers.
+     *
+     * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-has-content.md
+     * */
+    'jsx-a11y/anchor-has-content': WARNING,
+
+    /**
+     * Enforces proper use of anchor tag.
+     *
+     * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md
+     * */
+    'jsx-a11y/anchor-is-valid': [
+      WARNING,
+      {
+        aspects: ['noHref', 'invalidHref'],
+      },
+    ],
+
+    /**
+     * This will fail if it finds an aria-* property that is not listed in WAI-ARIA States and Properties spec.
+     *
+     * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-props.md
+     * */
+    'jsx-a11y/aria-props': WARNING,
+
+    /**
+     * ARIA state and property values must be valid.
+     *
+     * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-proptypes.md
+     * */
+    'jsx-a11y/aria-proptypes': WARNING,
+
+    /**
+     * Elements with ARIA roles must use a valid, non-abstract ARIA role.
+     *
+     * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-role.md
+     * */
+    'jsx-a11y/aria-role': [WARNING, { ignoreNonDOM: true }],
+
+    /**
+     * This rule enforces that these DOM elements do not contain the role and/or aria-* props.
+     *
+     * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-unsupported-elements.md
+     * */
+    'jsx-a11y/aria-unsupported-elements': WARNING,
+
+    /**
+     * Enforce that heading elements (h1, h2, etc.) have content and that the content is accessible to screen readers.
+     *
+     * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/heading-has-content.md
+     * */
+    'jsx-a11y/heading-has-content': WARNING,
+
+    /**
+     * Enforce img alt attribute does not contain the word image, picture, or photo.
+     *
+     * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/img-redundant-alt.md
+     * */
+    'jsx-a11y/img-redundant-alt': WARNING,
+
+    /**
+     * Enforce no accessKey prop on element.
+     *
+     * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-access-key.md
+     * */
+    'jsx-a11y/no-access-key': WARNING,
+
+    /**
+     * Enforces that no distracting elements are used.
+     *
+     * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-distracting-elements.md
+     * */
+    'jsx-a11y/no-distracting-elements': WARNING,
+
+    /**
+     * Setting an ARIA role that matches its default/implicit role is redundant since it is already set by the browser.
+     *
+     * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-redundant-roles.md
+     * */
+    'jsx-a11y/no-redundant-roles': WARNING,
+
+    /**
+     * Enforce that elements with explicit or implicit roles defined contain only aria-* properties supported by that role.
+     *
+     * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/role-supports-aria-props.md
+     * */
+    'jsx-a11y/role-supports-aria-props': WARNING,
   },
 };

--- a/packages/eslint-plugin/configs/react.js
+++ b/packages/eslint-plugin/configs/react.js
@@ -3,12 +3,7 @@
  * */
 'use strict';
 
-const {
-  OFF,
-  ERROR,
-  WARNING,
-  INCONSISTENCY,
-} = require('./internal/error-codes');
+const { OFF, ERROR, INCONSISTENCY } = require('./internal/error-codes');
 
 /**
  * @type {Config}
@@ -97,102 +92,83 @@ module.exports = {
      *
      * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/accessible-emoji.md
      * */
-    'jsx-a11y/accessible-emoji': WARNING,
-
-    /**
-     * Enforce that all elements that require alternative text have meaningful information to relay back to the end user.
-     *
-     * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/alt-text.md
-     * */
-    'jsx-a11y/alt-text': WARNING,
-
-    /**
-     * Enforce that anchors have content and that the content is accessible to screen readers.
-     *
-     * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-has-content.md
-     * */
-    'jsx-a11y/anchor-has-content': WARNING,
-
-    /**
-     * Enforces proper use of anchor tag.
-     *
-     * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md
-     * */
-    'jsx-a11y/anchor-is-valid': [
-      WARNING,
-      {
-        aspects: ['noHref', 'invalidHref'],
-      },
-    ],
+    'jsx-a11y/accessible-emoji': INCONSISTENCY,
 
     /**
      * This will fail if it finds an aria-* property that is not listed in WAI-ARIA States and Properties spec.
      *
      * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-props.md
      * */
-    'jsx-a11y/aria-props': WARNING,
+    'jsx-a11y/aria-props': INCONSISTENCY,
 
     /**
      * ARIA state and property values must be valid.
      *
      * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-proptypes.md
      * */
-    'jsx-a11y/aria-proptypes': WARNING,
+    'jsx-a11y/aria-proptypes': INCONSISTENCY,
 
     /**
      * Elements with ARIA roles must use a valid, non-abstract ARIA role.
      *
      * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-role.md
      * */
-    'jsx-a11y/aria-role': [WARNING, { ignoreNonDOM: true }],
-
-    /**
-     * This rule enforces that these DOM elements do not contain the role and/or aria-* props.
-     *
-     * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-unsupported-elements.md
-     * */
-    'jsx-a11y/aria-unsupported-elements': WARNING,
-
-    /**
-     * Enforce that heading elements (h1, h2, etc.) have content and that the content is accessible to screen readers.
-     *
-     * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/heading-has-content.md
-     * */
-    'jsx-a11y/heading-has-content': WARNING,
-
-    /**
-     * Enforce img alt attribute does not contain the word image, picture, or photo.
-     *
-     * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/img-redundant-alt.md
-     * */
-    'jsx-a11y/img-redundant-alt': WARNING,
+    'jsx-a11y/aria-role': [INCONSISTENCY, { ignoreNonDOM: true }],
 
     /**
      * Enforce no accessKey prop on element.
      *
      * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-access-key.md
      * */
-    'jsx-a11y/no-access-key': WARNING,
-
-    /**
-     * Enforces that no distracting elements are used.
-     *
-     * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-distracting-elements.md
-     * */
-    'jsx-a11y/no-distracting-elements': WARNING,
+    'jsx-a11y/no-access-key': INCONSISTENCY,
 
     /**
      * Setting an ARIA role that matches its default/implicit role is redundant since it is already set by the browser.
      *
      * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-redundant-roles.md
      * */
-    'jsx-a11y/no-redundant-roles': WARNING,
+    'jsx-a11y/no-redundant-roles': INCONSISTENCY,
 
     /**
      * Enforce that elements with explicit or implicit roles defined contain only aria-* properties supported by that role.
      *
      * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/role-supports-aria-props.md
      * */
-    'jsx-a11y/role-supports-aria-props': WARNING,
+    'jsx-a11y/role-supports-aria-props': INCONSISTENCY,
+
+    /**
+     * Enforce elements with aria-activedescendant are tabbable.
+     *
+     * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-activedescendant-has-tabindex.md
+     * */
+    'jsx-a11y/aria-activedescendant-has-tabindex': INCONSISTENCY,
+
+    /**
+     * Enforce autoFocus prop is not used.
+     *
+     * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-autofocus.md
+     * */
+    'jsx-a11y/no-autofocus': INCONSISTENCY,
+
+    /**
+     * Enforce that elements with ARIA roles must have all required attributes for that role.
+     *
+     * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/role-has-required-aria-props.md
+     * */
+    'jsx-a11y/role-has-required-aria-props': INCONSISTENCY,
+
+    /**
+     * Enforce scope prop is only used on elements.
+     *
+     * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/scope.md
+     * */
+    'jsx-a11y/scope': INCONSISTENCY,
+
+    /**
+     * Enforce tabIndex value is not greater than zero.
+     *
+     * @see https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/tabindex-no-positive.md
+     * */
+    'jsx-a11y/tabindex-no-positive': INCONSISTENCY,
   },
 };

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -24,10 +24,12 @@
     "eslint-plugin-eslint-comments": "3.x",
     "eslint-plugin-import": "2.x",
     "eslint-plugin-jest": "23.x",
+    "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-node": "11.x",
     "eslint-plugin-react": "7.x",
     "eslint-plugin-react-hooks": "2.x",
     "eslint-plugin-simple-import-sort": "5.x",
+    "eslint-plugin-testing-library": "^3.0.0",
     "lodash": "4.x"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -888,7 +888,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.4.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.9.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.2.tgz#d90df0583a3a252f09aaa619665367bae518db06"
   integrity sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==
@@ -2428,6 +2428,14 @@ argv@0.0.2:
   resolved "https://registry.yarnpkg.com/argv/-/argv-0.0.2.tgz#ecbd16f8949b157183711b1bda334f37840185ab"
   integrity sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=
 
+aria-query@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-3.0.0.tgz#65b3fcc1ca1155a8c9ae64d6eee297f15d5133cc"
+  integrity sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=
+  dependencies:
+    ast-types-flow "0.0.7"
+    commander "^2.11.0"
+
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
@@ -2529,6 +2537,11 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
+ast-types-flow@0.0.7, ast-types-flow@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
+  integrity sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
+
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
@@ -2563,6 +2576,11 @@ aws4@^1.8.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
   integrity sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
+
+axobject-query@^2.0.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.1.2.tgz#2bdffc0371e643e5f03ba99065d5179b9ca79799"
+  integrity sha512-ICt34ZmrVt8UQnvPl6TVyDTkmhXmAyAT4Jh5ugfGUX4MOrZ+U/ZY6/sdylRw3qGNr9Ub5AJsaHeDMzNLehRdOQ==
 
 babel-jest@^25.1.0:
   version "25.1.0"
@@ -3066,15 +3084,15 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@^2.11.0, commander@~2.20.3:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
 commander@^4.0.1, commander@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
-
-commander@~2.20.3:
-  version "2.20.3"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
-  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 compare-func@^1.3.1:
   version "1.3.2"
@@ -3336,6 +3354,11 @@ cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
+
+damerau-levenshtein@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz#143c1641cb3d85c60c32329e26899adea8701791"
+  integrity sha512-JVrozIeElnj3QzfUIt8tB8YMluBJom4Vw9qTPpjGYQ9fYlB3D/rb6OordUxf3xeFB35LKWs0xqcO5U6ySvBtug==
 
 dargs@^4.0.1:
   version "4.1.0"
@@ -3600,7 +3623,7 @@ elegant-spinner@^1.0.1:
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
   integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
 
-emoji-regex@^7.0.1:
+emoji-regex@^7.0.1, emoji-regex@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
   integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
@@ -3770,6 +3793,21 @@ eslint-plugin-jest@23.x:
   dependencies:
     "@typescript-eslint/experimental-utils" "^2.5.0"
 
+eslint-plugin-jsx-a11y@^6.2.3:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz#b872a09d5de51af70a97db1eea7dc933043708aa"
+  integrity sha512-CawzfGt9w83tyuVekn0GDPU9ytYtxyxyFZ3aSWROmnRRFQFT2BiPJd7jvRdzNDi6oLWaS2asMeYSNMjWTV4eNg==
+  dependencies:
+    "@babel/runtime" "^7.4.5"
+    aria-query "^3.0.0"
+    array-includes "^3.0.3"
+    ast-types-flow "^0.0.7"
+    axobject-query "^2.0.2"
+    damerau-levenshtein "^1.0.4"
+    emoji-regex "^7.0.2"
+    has "^1.0.3"
+    jsx-ast-utils "^2.2.1"
+
 eslint-plugin-node@11.x:
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-11.0.0.tgz#365944bb0804c5d1d501182a9bc41a0ffefed726"
@@ -3809,6 +3847,11 @@ eslint-plugin-simple-import-sort@5.x:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-5.0.2.tgz#43b5c4ab5affa2dd8481ef40216c71723becd2e2"
   integrity sha512-YPEGo7DbMANQ01d2OXlREcaHRszsW8LoUQ9mIjI7gXSdwpnWKfogtzL6FiBfDf1teCBx+AdcjcfDXSKpmhTWeA==
+
+eslint-plugin-testing-library@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-3.0.0.tgz#28070ce60a224447b8ef66add277b9459a8a1382"
+  integrity sha512-qsYRGqs+foeAznXXzOzZMd+czd9meeZwQ8HabpOi9xm39pQqa06cJx6XzdgoR1sRLOKJhhBTpascBS6b6b6SiQ==
 
 eslint-scope@^5.0.0:
   version "5.0.0"
@@ -5705,7 +5748,7 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-jsx-ast-utils@^2.2.3:
+jsx-ast-utils@^2.2.1, jsx-ast-utils@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.2.3.tgz#8a9364e402448a3ce7f14d357738310d9248054f"
   integrity sha512-EdIHFMm+1BPynpKOpdPqiOsvnIrInRGJD7bzPZdPkjitQEqpdpUuFpq4T0npZFKTiB3RhWFdGN+oqOJIdhDhQA==


### PR DESCRIPTION
Most jsx-a11y rules are take from  [eslint-config-react-app](https://github.com/facebook/create-react-app/blob/master/packages/eslint-config-react-app/index.js)